### PR TITLE
Fix integration tests; Fix manifest-level service

### DIFF
--- a/lib/iiif/service.rb
+++ b/lib/iiif/service.rb
@@ -206,7 +206,7 @@ module IIIF
 
       hsh.keys.each do |key|
         new_key = key.underscore == key ? key : key.underscore
-        if new_key == 'service'
+        if new_key == 'service' && !hsh[key].kind_of?(Array) 
           new_object[new_key] = IIIF::Service.from_ordered_hash(hsh[key], IIIF::Service)
         elsif new_key == 'resource'
           new_object[new_key] = IIIF::Service.from_ordered_hash(hsh[key], IIIF::Presentation::Resource)

--- a/spec/fixtures/manifests/complete_from_spec.json
+++ b/spec/fixtures/manifests/complete_from_spec.json
@@ -25,11 +25,20 @@
   "description": "A longer description of this example book. It should give some real information.",
   "license": "http://www.example.org/license.html",
   "attribution": "Provided by Example Organization",
-  "service": {
-    "@context": "http://example.org/ns/jsonld/context.json",
-    "@id": "http://example.org/service/example",
-    "profile": "http://example.org/docs/example-service.html"
-  },
+  "service": [
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b11847736-0/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    },
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b11847736",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: artwork, Institution: n/a, Identifier: b11847736, Digicode: digicon, Collection code: n/a"
+    }
+  ],
   "seeAlso": {
     "@id": "http://www.example.org/library/catalog/book1.marc",
     "format": "application/marc"

--- a/spec/integration/iiif/presentation/image_resource_spec.rb
+++ b/spec/integration/iiif/presentation/image_resource_spec.rb
@@ -54,7 +54,7 @@ describe IIIF::Presentation::ImageResource do
           {
             'supports' => [
               'canonicalLinkHeader', 'profileLinkHeader', 'mirroring',
-              'rotationArbitrary', 'sizeAboveFull'
+              'rotationArbitrary', 'regionSquare', 'sizeAboveFull'
             ],
             'qualities' => ['default', 'bitonal', 'gray', 'color'],
             'formats'=>['jpg', 'png', 'gif', 'webp']

--- a/spec/integration/iiif/presentation/image_resource_spec.rb
+++ b/spec/integration/iiif/presentation/image_resource_spec.rb
@@ -1,4 +1,3 @@
-require 'pry'
 describe IIIF::Presentation::ImageResource do
   vcr_options = {
     cassette_name: 'pul_loris_cassette',

--- a/spec/integration/iiif/presentation/image_resource_spec.rb
+++ b/spec/integration/iiif/presentation/image_resource_spec.rb
@@ -1,3 +1,4 @@
+require 'pry'
 describe IIIF::Presentation::ImageResource do
   vcr_options = {
     cassette_name: 'pul_loris_cassette',
@@ -7,15 +8,14 @@ describe IIIF::Presentation::ImageResource do
 
   describe 'self#create_image_api_image_resource', vcr: vcr_options do
 
-    let(:image_server) { 'http://libimages.princeton.edu/loris2' }
-
+    let(:image_server) { 'https://libimages.princeton.edu/loris' }
     let(:valid_service_id) {
-      id = 'pudl0001%2F4612422%2F00000001.jp2'
+      id = 'pudl0001/4612422/00000001.jp2'
       "#{image_server}/#{id}"
     }
 
     let(:invalid_service_id) {
-      id = 'xxxx%2F4612422%2F00000001.jp2'
+      id = 'xxxx/4612422/00000001.jp2'
       "#{image_server}/#{id}"
     }
 
@@ -31,25 +31,25 @@ describe IIIF::Presentation::ImageResource do
         resource = described_class.create_image_api_image_resource(opts)
         # expect(resource['@context']).to eq 'http://iiif.io/api/presentation/2/context.json'
         # @context is only added when we call to_json...
-        expect(resource['@id']).to eq 'http://libimages.princeton.edu/loris2/pudl0001%2F4612422%2F00000001.jp2/full/!200,200/0/default.jpg'
+        expect(resource['@id']).to eq 'https://libimages.princeton.edu/loris/pudl0001/4612422/00000001.jp2/full/!200,200/0/default.jpg'
         expect(resource['@type']).to eq 'dctypes:Image'
         expect(resource.format).to eq "image/jpeg"
         expect(resource.width).to eq 3047
         expect(resource.height).to eq 7200
         expect(resource.service['@context']).to eq 'http://iiif.io/api/image/2/context.json'
-        expect(resource.service['@id']).to eq 'http://libimages.princeton.edu/loris2/pudl0001%2F4612422%2F00000001.jp2'
+        expect(resource.service['@id']).to eq 'https://libimages.princeton.edu/loris/pudl0001/4612422/00000001.jp2'
         expect(resource.service['profile']).to eq 'http://iiif.io/api/image/2/level2.json'
       end
       it 'copies over all teh infos (when copy_info is true)' do
         opts = { service_id: valid_service_id, copy_info: true }
         resource = described_class.create_image_api_image_resource(opts)
-        expect(resource['@id']).to eq 'http://libimages.princeton.edu/loris2/pudl0001%2F4612422%2F00000001.jp2/full/!200,200/0/default.jpg'
+        expect(resource['@id']).to eq 'https://libimages.princeton.edu/loris/pudl0001/4612422/00000001.jp2/full/!200,200/0/default.jpg'
         expect(resource['@type']).to eq 'dctypes:Image'
         expect(resource.format).to eq "image/jpeg"
         expect(resource.width).to eq 3047
         expect(resource.height).to eq 7200
         expect(resource.service['@context']).to eq 'http://iiif.io/api/image/2/context.json'
-        expect(resource.service['@id']).to eq 'http://libimages.princeton.edu/loris2/pudl0001%2F4612422%2F00000001.jp2'
+        expect(resource.service['@id']).to eq 'https://libimages.princeton.edu/loris/pudl0001%2F4612422%2F00000001.jp2'  # I do not know why this would be partially escaped, but I am not Princeton
         expect(resource.service['profile']).to eq [
           'http://iiif.io/api/image/2/level2.json',
           {


### PR DESCRIPTION
This code change correctly handles valid manifests that include an array of services, which is common at the [Wellcome](https://wellcomelibrary.org/iiif/b21051951/manifest) and many other IIIF content providers.  Previously, osullivan died with an exception when trying to parse these manifests.  

Along the way, this PR also fixes stale integration tests that relied on outdated URIs for manifests at Princeton.  That test code should probably be reviewed by @cbeer.

This PR replaces #61, which can be closed.