### PR TITLE
Validate Range items as Canvas OR Range

### DIFF
--- a/lib/iiif/v3/presentation/range.rb
+++ b/lib/iiif/v3/presentation/range.rb
@@ -40,7 +40,7 @@ module IIIF
         def validate_list(canvas_array)
           return if canvas_array.all? { |entry| VALID_ITEM_TYPES.include?(entry.class) }
 
-          m = "All entries in the (items or canvases) array must be: #{VALID_ITEM_TYPES.join(', ')}"
+          m = "All entries in the (items or canvases) array must be one of #{VALID_ITEM_TYPES.join(', ')}"
           raise IIIF::V3::Presentation::IllegalValueError, m
         end
       end

--- a/lib/iiif/v3/presentation/range.rb
+++ b/lib/iiif/v3/presentation/range.rb
@@ -3,8 +3,8 @@ module IIIF
     module Presentation
       # Ranges are linked or embedded within the manifest in a structures field
       class Range < Sequence
-
         TYPE = 'Range'.freeze
+        VALID_ITEM_TYPES = [IIIF::V3::Presentation::Canvas, IIIF::V3::Presentation::Range]
 
         def required_keys
           super + %w{ id label }
@@ -28,10 +28,20 @@ module IIIF
 
         def validate
           super
+          validate_list(self['items']) if self['items']
+          validate_list(self['canvases']) if self['canvases']
           # TODO: Ranges must have URIs and they should be http(s) URIs.
-          # TODO: Values of the members array must be canvas or range
           # TODO: contentAnnotations: links to AnnotationCollection
           # TODO: startCanvas: A link from a Sequence or Range to a Canvas that is contained within it
+        end
+
+        private
+
+        def validate_list(canvas_array)
+          return if canvas_array.all? { |entry| VALID_ITEM_TYPES.include?(entry.class) }
+
+          m = "All entries in the (items or canvases) array must be: #{VALID_ITEM_TYPES.join(', ')}"
+          raise IIIF::V3::Presentation::IllegalValueError, m
         end
       end
     end

--- a/lib/iiif/v3/presentation/sequence.rb
+++ b/lib/iiif/v3/presentation/sequence.rb
@@ -37,28 +37,13 @@ module IIIF
           # NOTE: allowing 'items' or 'canvases' as Universal Viewer currently only accepts canvases
           #  see https://github.com/sul-dlss/osullivan/issues/27, sul-dlss/purl/issues/167
           unless (self['items'] && self['items'].any?) ||
-              (self['canvases'] && self['canvases'].any?)
-            m = 'The (items or canvases) list must have at least one entry (and it must be a IIIF::V3::Presentation::Canvas)'
+                 (self['canvases'] && self['canvases'].any?)
+            m = 'The (items or canvases) list must have at least one entry.'
             raise IIIF::V3::Presentation::MissingRequiredKeyError, m
           end
-          validate_canvas_list(self['items']) if self['items']
-          validate_canvas_list(self['canvases']) if self['canvases']
-
           # TODO: startCanvas: A link from a Sequence or Range to a Canvas that is contained within it
 
           # TODO: All external Sequences must have a dereference-able http(s) URI
-        end
-
-        def validate_canvas_list(canvas_array)
-          unless canvas_array.size >= 1
-            m = 'The (items or canvases) list must have at least one entry (and it must be a IIIF::V3::Presentation::Canvas)'
-            raise IIIF::V3::Presentation::MissingRequiredKeyError, m
-          end
-
-          unless canvas_array.all? { |entry| entry.instance_of?(IIIF::V3::Presentation::Canvas) }
-            m = 'All entries in the (items or canvases) list must be a IIIF::V3::Presentation::Canvas'
-            raise IIIF::V3::Presentation::IllegalValueError, m
-          end
         end
       end
     end

--- a/spec/unit/iiif/v3/presentation/range_spec.rb
+++ b/spec/unit/iiif/v3/presentation/range_spec.rb
@@ -49,6 +49,25 @@ describe IIIF::V3::Presentation::Range do
   end
 
   describe '#validate' do
+    let(:bad_val_msg) do
+      "All entries in the (items or canvases) array must be one of #{IIIF::V3::Presentation::Range::VALID_ITEM_TYPES.join(', ')}"
+    end
+    describe 'items' do
+      it 'raises IllegalValueError for items entry that is not valid type' do
+        subject['id'] = 'test_range'
+        subject['label'] = { 'en' => ['Test Range'] }
+        subject['items'] = [IIIF::V3::Presentation::Range.new('id' => 'child_range', 'label' => ['Child Label']),
+                            IIIF::V3::Presentation::AnnotationPage.new]
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, bad_val_msg)
+      end
+    end
+    describe 'canvases' do
+      it 'raises IllegalValueError for canvases entry that is not valid type' do
+        subject['id'] = 'test_range'
+        subject['label'] = { 'en' => ['Test Range'] }
+        subject['canvases'] = [IIIF::V3::Presentation::Canvas.new, IIIF::V3::Presentation::AnnotationPage.new]
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, bad_val_msg)
+      end
+    end
   end
-
 end

--- a/spec/unit/iiif/v3/presentation/sequence_spec.rb
+++ b/spec/unit/iiif/v3/presentation/sequence_spec.rb
@@ -57,8 +57,7 @@ describe IIIF::V3::Presentation::Sequence do
   end
 
   describe '#validate' do
-    let(:req_key_msg) { "The (items or canvases) list must have at least one entry (and it must be a IIIF::V3::Presentation::Canvas)" }
-    let(:bad_val_msg) { "All entries in the (items or canvases) list must be a IIIF::V3::Presentation::Canvas" }
+    let(:req_key_msg) { "The (items or canvases) list must have at least one entry." }
     it 'raises MissingRequiredKeyError if no items or canvases key' do
       expect { subject.validate }.to raise_error(IIIF::V3::Presentation::MissingRequiredKeyError, req_key_msg)
     end
@@ -67,19 +66,11 @@ describe IIIF::V3::Presentation::Sequence do
         subject['items'] = []
         expect { subject.validate }.to raise_error(IIIF::V3::Presentation::MissingRequiredKeyError, req_key_msg)
       end
-      it 'raises IllegalValueError for items entry that is not a Canvas' do
-        subject['items'] = [IIIF::V3::Presentation::Canvas.new, IIIF::V3::Presentation::AnnotationPage.new]
-        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, bad_val_msg)
-      end
     end
     describe 'canvases' do
       it 'raises MissingRequiredKeyError for canvases as empty Array' do
         subject['items'] = []
         expect { subject.validate }.to raise_error(IIIF::V3::Presentation::MissingRequiredKeyError, req_key_msg)
-      end
-      it 'raises IllegalValueError for canvases entry that is not a Canvas' do
-        subject['canvases'] = [IIIF::V3::Presentation::Canvas.new, IIIF::V3::Presentation::AnnotationPage.new]
-        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, bad_val_msg)
       end
     end
   end


### PR DESCRIPTION
Closes #93 

This MR addresses a `TODO` in the `Range` class. We want to make sure that any child item (or canvas, for UV) is either a `Canvas` or `Range`. However - the `Sequence` class that `Range` inherits from does a validation that works against this logic:

```ruby
unless canvas_array.all? { |entry| entry.instance_of?(IIIF::V3::Presentation::Canvas) }
  m = 'All entries in the (items or canvases) list must be a IIIF::V3::Presentation::Canvas'
  raise IIIF::V3::Presentation::IllegalValueError, m
end
```

As you can see, this is ensuring that every item (or canvas) is a `Canvas` object - meaning `Range` values are not supported. The IIIF V3 spec details the following:

> Top level Ranges are [embedded](https://iiif.io/api/presentation/3.0/#12-terminology) or externally [referenced](https://iiif.io/api/presentation/3.0/#12-terminology) within the Manifest in a structures property. These top level Ranges then embed or reference other Ranges, Canvases or parts of Canvases in the items property. Each entry in the items property must be a JSON object, and it must have the id and type properties.

My proposal is this: remove the validation from the `Sequence` class and into the `Range` class that inherits from it - the `Sequence` class should not be responsible for validating the items array, but rather the class that inherits from it.

Ideally, we'd probably want to remove the `Sequence` class, as it's a holdover from the v2 IIIF spec - however, it performs some important validation that we probably want to keep for the time being. This is just a fix that will expand the current code to support the v3 IIIF spec more closely. 