### PR TITLE
Re-use results of key inflection calls

### DIFF
--- a/lib/iiif/ordered_hash.rb
+++ b/lib/iiif/ordered_hash.rb
@@ -87,8 +87,10 @@ module IIIF
     # Covert snake_case keys to camelCase
     def camelize_keys
       self.keys.each_with_index do |key, i|
-        if key != key.camelize(:lower)
-          self.insert(i, key.camelize(:lower), self[key])
+        camelized_key = key.camelize(:lower)
+
+        if key != camelized_key
+          self.insert(i, camelized_key, self[key])
           self.delete(key)
         end
       end

--- a/lib/iiif/service.rb
+++ b/lib/iiif/service.rb
@@ -321,13 +321,15 @@ module IIIF
 
     def define_accessor_methods(*keys, &validation)
       keys.each do |key|
+        camelized_key = key.camelize(:lower)
+
         # Setter
         define_singleton_method("#{key}=") do |arg|
           validation.call(key, arg) if block_given?
           self.send('[]=', key, arg)
         end
-        if key.camelize(:lower) != key
-          define_singleton_method("#{key.camelize(:lower)}=") do |arg|
+        if camelized_key != key
+          define_singleton_method("#{camelized_key}=") do |arg|
             validation.call(key, arg) if block_given?
             self.send('[]=', key, arg)
           end
@@ -337,8 +339,8 @@ module IIIF
           self[key] ||= []
           self[key]
         end
-        if key.camelize(:lower) != key
-          define_singleton_method(key.camelize(:lower)) do
+        if camelized_key != key
+          define_singleton_method(camelized_key) do
             self.send('[]', key)
           end
         end

--- a/lib/iiif/v3/abstract_resource.rb
+++ b/lib/iiif/v3/abstract_resource.rb
@@ -447,13 +447,15 @@ module IIIF
 
       def define_accessor_methods(*keys, &validation)
         keys.each do |key|
+          camelized_key = key.camelize(:lower)
+
           # Setter
           define_singleton_method("#{key}=") do |val|
             validation.call(key, val) if block_given?
             self.send('[]=', key, val)
           end
-          if key.camelize(:lower) != key
-            define_singleton_method("#{key.camelize(:lower)}=") do |val|
+          if camelized_key != key
+            define_singleton_method("#{camelized_key}=") do |val|
               validation.call(key, val) if block_given?
               self.send('[]=', key, val)
             end
@@ -463,8 +465,8 @@ module IIIF
             self[key] ||= []
             self[key]
           end
-          if key.camelize(:lower) != key
-            define_singleton_method(key.camelize(:lower)) do
+          if camelized_key != key
+            define_singleton_method(camelized_key) do
               self.send('[]', key)
             end
           end


### PR DESCRIPTION
I'm chasing down some performance issues I'm seeing for some of our very large manifests. I noticed that it seems we pay the full price for each repeated `key.camelize` call. It might make sense to compute those once and re-use the saved value.

Using the fixture data in our [Purl app](https://github.com/sul-dlss/purl) for https://purl.stanford.edu/bc854fy5899 to get to the point where we can return the result of `to_ordered_hash` the the `memory_profiler` gem reports the following for this change:

"allocated memory by gem" for activesupport-8.0.2 drops from 120401765 to 44878373
"allocated objects by gem" for activesupport-8.0.2 drops from 1600601 to 606617

