### PR TITLE
Stop using obsolete URI.regexp for validation

### DIFF
--- a/lib/iiif/v3/abstract_resource.rb
+++ b/lib/iiif/v3/abstract_resource.rb
@@ -472,11 +472,12 @@ module IIIF
       end
 
       private
+
       def validate_uri(val, key)
-        unless val.kind_of?(String) && val =~ /\A#{URI::regexp}\z/
-          m = "#{key} value must be a String containing a URI for #{self.class}"
-          raise IIIF::V3::Presentation::IllegalValueError, m
-        end
+        raise ArgumentError if URI(val).scheme.nil?
+      rescue URI::Error, ArgumentError
+        m = "#{key} value must be a String containing a URI for #{self.class}"
+        raise IIIF::V3::Presentation::IllegalValueError, m
       end
 
     end


### PR DESCRIPTION
With the same test setup as https://github.com/iiif-prezi/osullivan/pull/103 I'm seeing we could make some performance savings by not recompiling the regex in each call of `validate_uri`.

"allocated memory by class" for Regex goes from 9268983 to 31073